### PR TITLE
Fix offline Next.js build by removing remote font dependencies

### DIFF
--- a/frontend/socint-frontend/src/app/globals.css
+++ b/frontend/socint-frontend/src/app/globals.css
@@ -8,8 +8,11 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "SFMono-Regular",
+    ui-monospace, "DejaVu Sans Mono", Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +25,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/frontend/socint-frontend/src/app/layout.tsx
+++ b/frontend/socint-frontend/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- remove Google Font dependencies from the root layout to prevent network fetch failures during builds
- update the global theme to use local-friendly system font stacks for sans and mono usage

## Testing
- pnpm install
- CI=1 pnpm build
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e5b873ffe8832ab71b1122cd5c3d49